### PR TITLE
feat: 入力モーダルの改善 (close #15)

### DIFF
--- a/src/components/CompleteModal.test.tsx
+++ b/src/components/CompleteModal.test.tsx
@@ -17,18 +17,18 @@ const createTask = (overrides: Partial<Task> = {}): Task => ({
 });
 
 describe('CompleteModal', () => {
-  it('renders modal with task name', () => {
+  it('renders modal with task name as h2', () => {
     const task = createTask({ name: 'My Task' });
     const onComplete = vi.fn();
     const onCancel = vi.fn();
 
     render(<CompleteModal task={task} onComplete={onComplete} onCancel={onCancel} />);
 
-    expect(screen.getByText('タスク完了')).toBeInTheDocument();
-    expect(screen.getByText('「My Task」を完了としてマークします')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'My Task', level: 2 })).toBeInTheDocument();
+    expect(screen.getByText('タスクを完了します')).toBeInTheDocument();
   });
 
-  it('initializes form with existing task data', () => {
+  it('initializes form with existing task data split by newlines', () => {
     const task = createTask({
       progress: 'Existing progress',
       remaining: 'Existing remaining',
@@ -55,7 +55,7 @@ describe('CompleteModal', () => {
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
 
-  it('calls onComplete with form data when submitted', async () => {
+  it('calls onComplete with newline-joined strings when submitted', async () => {
     const user = userEvent.setup();
     const task = createTask();
     const onComplete = vi.fn();
@@ -63,8 +63,11 @@ describe('CompleteModal', () => {
 
     render(<CompleteModal task={task} onComplete={onComplete} onCancel={onCancel} />);
 
-    await user.type(screen.getByPlaceholderText('完了時の状況や成果を記録...'), 'Completion notes');
-    await user.type(screen.getByPlaceholderText('今後のために残しておきたいメモ...'), 'Future notes');
+    const progressInputs = screen.getAllByPlaceholderText('完了時の状況や成果を記録...');
+    const remainingInputs = screen.getAllByPlaceholderText('今後のために残しておきたいメモ...');
+
+    await user.type(progressInputs[0], 'Completion notes');
+    await user.type(remainingInputs[0], 'Future notes');
     await user.click(screen.getByText('完了にする'));
 
     expect(onComplete).toHaveBeenCalledWith({
@@ -72,6 +75,75 @@ describe('CompleteModal', () => {
       nextStep: '',
       remaining: 'Future notes',
     });
+  });
+
+  it('adds a new list item when + 追加 button is clicked', async () => {
+    const user = userEvent.setup();
+    const task = createTask();
+    const onComplete = vi.fn();
+    const onCancel = vi.fn();
+
+    render(<CompleteModal task={task} onComplete={onComplete} onCancel={onCancel} />);
+
+    const addButtons = screen.getAllByText('+ 追加');
+    expect(screen.getAllByPlaceholderText('完了時の状況や成果を記録...')).toHaveLength(1);
+
+    await user.click(addButtons[0]);
+
+    expect(screen.getAllByPlaceholderText('完了時の状況や成果を記録...')).toHaveLength(2);
+  });
+
+  it('removes a list item when × button is clicked', async () => {
+    const user = userEvent.setup();
+    const task = createTask({ progress: 'item1\nitem2' });
+    const onComplete = vi.fn();
+    const onCancel = vi.fn();
+
+    render(<CompleteModal task={task} onComplete={onComplete} onCancel={onCancel} />);
+
+    expect(screen.getAllByPlaceholderText('完了時の状況や成果を記録...')).toHaveLength(2);
+
+    const removeButtons = screen.getAllByText('×');
+    await user.click(removeButtons[0]);
+
+    expect(screen.getAllByPlaceholderText('完了時の状況や成果を記録...')).toHaveLength(1);
+  });
+
+  it('disables remove button when only one item remains', () => {
+    const task = createTask();
+    const onComplete = vi.fn();
+    const onCancel = vi.fn();
+
+    render(<CompleteModal task={task} onComplete={onComplete} onCancel={onCancel} />);
+
+    const removeButtons = screen.getAllByText('×');
+    expect(removeButtons[0]).toBeDisabled();
+  });
+
+  it('submits multiple progress items joined by newlines', async () => {
+    const user = userEvent.setup();
+    const task = createTask();
+    const onComplete = vi.fn();
+    const onCancel = vi.fn();
+
+    render(<CompleteModal task={task} onComplete={onComplete} onCancel={onCancel} />);
+
+    const progressInputs = screen.getAllByPlaceholderText('完了時の状況や成果を記録...');
+    await user.type(progressInputs[0], 'Done 1');
+
+    const addButtons = screen.getAllByText('+ 追加');
+    await user.click(addButtons[0]);
+
+    const progressInputsAfter = screen.getAllByPlaceholderText('完了時の状況や成果を記録...');
+    await user.type(progressInputsAfter[1], 'Done 2');
+
+    await user.click(screen.getByText('完了にする'));
+
+    expect(onComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        progress: 'Done 1\nDone 2',
+      })
+    );
   });
 
   it('updates progress field on change', async () => {
@@ -82,7 +154,7 @@ describe('CompleteModal', () => {
 
     render(<CompleteModal task={task} onComplete={onComplete} onCancel={onCancel} />);
 
-    const progressInput = screen.getByPlaceholderText('完了時の状況や成果を記録...');
+    const progressInput = screen.getAllByPlaceholderText('完了時の状況や成果を記録...')[0];
     await user.type(progressInput, 'Updated progress');
 
     expect(progressInput).toHaveValue('Updated progress');
@@ -96,7 +168,7 @@ describe('CompleteModal', () => {
 
     render(<CompleteModal task={task} onComplete={onComplete} onCancel={onCancel} />);
 
-    const remainingInput = screen.getByPlaceholderText('今後のために残しておきたいメモ...');
+    const remainingInput = screen.getAllByPlaceholderText('今後のために残しておきたいメモ...')[0];
     await user.type(remainingInput, 'Updated remaining');
 
     expect(remainingInput).toHaveValue('Updated remaining');

--- a/src/components/CompleteModal.tsx
+++ b/src/components/CompleteModal.tsx
@@ -9,12 +9,30 @@ interface CompleteModalProps {
 }
 
 export function CompleteModal({ task, onComplete, onCancel }: CompleteModalProps) {
-  const [progress, setProgress] = useState(task.progress);
-  const [remaining, setRemaining] = useState(task.remaining);
+  const [progressItems, setProgressItems] = useState<string[]>(
+    task.progress ? task.progress.split('\n').filter(Boolean) : ['']
+  );
+  const [remainingItems, setRemainingItems] = useState<string[]>(
+    task.remaining ? task.remaining.split('\n').filter(Boolean) : ['']
+  );
+
+  const handleItemChange = (setter: React.Dispatch<React.SetStateAction<string[]>>, index: number, value: string) => {
+    setter(prev => prev.map((item, i) => i === index ? value : item));
+  };
+  const handleAddItem = (setter: React.Dispatch<React.SetStateAction<string[]>>) => {
+    setter(prev => [...prev, '']);
+  };
+  const handleRemoveItem = (setter: React.Dispatch<React.SetStateAction<string[]>>, index: number) => {
+    setter(prev => prev.filter((_, i) => i !== index));
+  };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    onComplete({ progress, nextStep: '', remaining });
+    onComplete({
+      progress: progressItems.filter(Boolean).join('\n'),
+      nextStep: '',
+      remaining: remainingItems.filter(Boolean).join('\n'),
+    });
   };
 
   return (
@@ -22,8 +40,8 @@ export function CompleteModal({ task, onComplete, onCancel }: CompleteModalProps
       <div className="modal complete-modal">
         <div className="modal-header">
           <div className="modal-icon">🎉</div>
-          <h2>タスク完了</h2>
-          <p className="modal-subtitle">「{task.name}」を完了としてマークします</p>
+          <h2 className="modal-task-name">{task.name}</h2>
+          <p className="modal-subtitle">タスクを完了します</p>
         </div>
 
         <form onSubmit={handleSubmit}>
@@ -32,12 +50,31 @@ export function CompleteModal({ task, onComplete, onCancel }: CompleteModalProps
               <span className="label-icon">📍</span>
               完了時のメモ（任意）
             </label>
-            <textarea
-              value={progress}
-              onChange={(e) => setProgress(e.target.value)}
-              placeholder="完了時の状況や成果を記録..."
-              rows={3}
-            />
+            <div className="list-input-group">
+              {progressItems.map((item, i) => (
+                <div key={i} className="list-input-row">
+                  <span className="list-bullet">•</span>
+                  <input
+                    type="text"
+                    value={item}
+                    onChange={(e) => handleItemChange(setProgressItems, i, e.target.value)}
+                    placeholder="完了時の状況や成果を記録..."
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') { e.preventDefault(); handleAddItem(setProgressItems); }
+                    }}
+                  />
+                  <button
+                    type="button"
+                    className="list-remove-btn"
+                    onClick={() => handleRemoveItem(setProgressItems, i)}
+                    disabled={progressItems.length === 1}
+                  >×</button>
+                </div>
+              ))}
+              <button type="button" className="list-add-btn" onClick={() => handleAddItem(setProgressItems)}>
+                + 追加
+              </button>
+            </div>
           </div>
 
           <div className="form-group">
@@ -45,12 +82,31 @@ export function CompleteModal({ task, onComplete, onCancel }: CompleteModalProps
               <span className="label-icon">📝</span>
               将来の参考・残課題（任意）
             </label>
-            <textarea
-              value={remaining}
-              onChange={(e) => setRemaining(e.target.value)}
-              placeholder="今後のために残しておきたいメモ..."
-              rows={2}
-            />
+            <div className="list-input-group">
+              {remainingItems.map((item, i) => (
+                <div key={i} className="list-input-row">
+                  <span className="list-bullet">•</span>
+                  <input
+                    type="text"
+                    value={item}
+                    onChange={(e) => handleItemChange(setRemainingItems, i, e.target.value)}
+                    placeholder="今後のために残しておきたいメモ..."
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') { e.preventDefault(); handleAddItem(setRemainingItems); }
+                    }}
+                  />
+                  <button
+                    type="button"
+                    className="list-remove-btn"
+                    onClick={() => handleRemoveItem(setRemainingItems, i)}
+                    disabled={remainingItems.length === 1}
+                  >×</button>
+                </div>
+              ))}
+              <button type="button" className="list-add-btn" onClick={() => handleAddItem(setRemainingItems)}>
+                + 追加
+              </button>
+            </div>
           </div>
 
           <div className="modal-actions">

--- a/src/components/LoadModal.test.tsx
+++ b/src/components/LoadModal.test.tsx
@@ -17,15 +17,15 @@ const createTask = (overrides: Partial<Task> = {}): Task => ({
 });
 
 describe('LoadModal', () => {
-  it('renders modal with task name', () => {
+  it('renders modal with task name as h2', () => {
     const task = createTask({ name: 'My Task' });
     const onLoad = vi.fn();
     const onCancel = vi.fn();
 
     render(<LoadModal task={task} onLoad={onLoad} onCancel={onCancel} />);
 
-    expect(screen.getByText('ロード')).toBeInTheDocument();
-    expect(screen.getByText('「My Task」を再開します')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'My Task', level: 2 })).toBeInTheDocument();
+    expect(screen.getByText('タスクを再開します')).toBeInTheDocument();
   });
 
   it('renders no save data message when task has no progress data', () => {
@@ -156,5 +156,28 @@ describe('LoadModal', () => {
 
     expect(screen.getByText('前回の進捗')).toBeInTheDocument();
     expect(screen.queryByText('残タスク')).not.toBeInTheDocument();
+  });
+
+  it('renders newline-delimited progress data as multiple list items', () => {
+    const task = createTask({ progress: 'Item 1\nItem 2\nItem 3' });
+    const onLoad = vi.fn();
+    const onCancel = vi.fn();
+
+    render(<LoadModal task={task} onLoad={onLoad} onCancel={onCancel} />);
+
+    expect(screen.getByText('Item 1')).toBeInTheDocument();
+    expect(screen.getByText('Item 2')).toBeInTheDocument();
+    expect(screen.getByText('Item 3')).toBeInTheDocument();
+  });
+
+  it('renders newline-delimited nextStep data as multiple list items', () => {
+    const task = createTask({ nextStep: 'Step A\nStep B' });
+    const onLoad = vi.fn();
+    const onCancel = vi.fn();
+
+    render(<LoadModal task={task} onLoad={onLoad} onCancel={onCancel} />);
+
+    expect(screen.getByText('Step A')).toBeInTheDocument();
+    expect(screen.getByText('Step B')).toBeInTheDocument();
   });
 });

--- a/src/components/LoadModal.tsx
+++ b/src/components/LoadModal.tsx
@@ -16,8 +16,8 @@ export function LoadModal({ task, onLoad, onCancel }: LoadModalProps) {
       <div className="modal load-modal">
         <div className="modal-header">
           <div className="modal-icon">📂</div>
-          <h2>ロード</h2>
-          <p className="modal-subtitle">「{task.name}」を再開します</p>
+          <h2 className="modal-task-name">{task.name}</h2>
+          <p className="modal-subtitle">タスクを再開します</p>
         </div>
 
         {hasProgress ? (
@@ -29,21 +29,33 @@ export function LoadModal({ task, onLoad, onCancel }: LoadModalProps) {
             {task.progress && (
               <div className="save-section">
                 <h3><span className="label-icon">📍</span> 前回の進捗</h3>
-                <p>{task.progress}</p>
+                <ul className="save-section-list">
+                  {task.progress.split('\n').filter(Boolean).map((item, i) => (
+                    <li key={i}>{item}</li>
+                  ))}
+                </ul>
               </div>
             )}
 
             {task.nextStep && (
               <div className="save-section highlight">
                 <h3><span className="label-icon">➡️</span> 次にやること</h3>
-                <p>{task.nextStep}</p>
+                <ul className="save-section-list">
+                  {task.nextStep.split('\n').filter(Boolean).map((item, i) => (
+                    <li key={i}>{item}</li>
+                  ))}
+                </ul>
               </div>
             )}
 
             {task.remaining && (
               <div className="save-section">
                 <h3><span className="label-icon">📝</span> 残タスク</h3>
-                <p>{task.remaining}</p>
+                <ul className="save-section-list">
+                  {task.remaining.split('\n').filter(Boolean).map((item, i) => (
+                    <li key={i}>{item}</li>
+                  ))}
+                </ul>
               </div>
             )}
           </div>

--- a/src/components/Modal.css
+++ b/src/components/Modal.css
@@ -21,10 +21,10 @@
   background: #1a1a2e;
   border: 2px solid #4a4a6a;
   border-radius: 12px;
-  padding: 24px;
-  width: 90%;
-  max-width: 500px;
-  max-height: 90vh;
+  padding: 32px;
+  width: 95%;
+  max-width: 720px;
+  max-height: 92vh;
   overflow-y: auto;
   box-shadow: 0 0 30px rgba(100, 100, 255, 0.2);
   animation: slideUp 0.3s ease;
@@ -199,4 +199,105 @@
 /* Complete Modal */
 .complete-modal .modal-header {
   color: #4aff4a;
+}
+
+.modal-task-name {
+  font-size: 22px;
+  font-weight: 700;
+  color: #fff;
+  margin: 8px 0 4px;
+  word-break: break-all;
+}
+
+.form-group label {
+  font-size: 13px;
+  font-weight: 600;
+  color: #9a9abb;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 10px;
+}
+
+.list-input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.list-input-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.list-input-row input {
+  flex: 1;
+  padding: 8px 12px;
+  background: #0f0f1a;
+  border: 1px solid #3a3a5a;
+  border-radius: 6px;
+  color: #fff;
+  font-size: 14px;
+}
+
+.list-bullet {
+  color: #6a6aff;
+  font-size: 18px;
+  width: 16px;
+  text-align: center;
+}
+
+.list-remove-btn {
+  background: none;
+  border: none;
+  color: #666;
+  cursor: pointer;
+  font-size: 16px;
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+
+.list-remove-btn:hover:not(:disabled) {
+  color: #ff6a6a;
+  background: rgba(255, 106, 106, 0.1);
+}
+
+.list-remove-btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.list-add-btn {
+  background: none;
+  border: 1px dashed #3a3a5a;
+  color: #6a6aff;
+  cursor: pointer;
+  font-size: 13px;
+  padding: 6px 12px;
+  border-radius: 6px;
+  margin-top: 4px;
+  text-align: left;
+}
+
+.list-add-btn:hover {
+  background: rgba(106, 106, 255, 0.1);
+  border-color: #6a6aff;
+}
+
+.save-section-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.save-section-list li {
+  padding: 4px 0;
+  color: #ccc;
+}
+
+.save-section-list li::before {
+  content: "•";
+  color: #6a6aff;
+  margin-right: 8px;
 }

--- a/src/components/Modal.css
+++ b/src/components/Modal.css
@@ -67,37 +67,8 @@
   margin-bottom: 16px;
 }
 
-.form-group label {
-  display: block;
-  color: #ccc;
-  margin-bottom: 8px;
-  font-size: 14px;
-}
-
 .label-icon {
   margin-right: 6px;
-}
-
-.form-group textarea {
-  width: 100%;
-  padding: 12px;
-  background: #0f0f1a;
-  border: 1px solid #3a3a5a;
-  border-radius: 8px;
-  color: #fff;
-  font-size: 14px;
-  resize: vertical;
-  font-family: inherit;
-  transition: border-color 0.2s;
-}
-
-.form-group textarea:focus {
-  outline: none;
-  border-color: #6a6aff;
-}
-
-.form-group textarea::placeholder {
-  color: #5a5a7a;
 }
 
 .modal-actions {
@@ -210,6 +181,7 @@
 }
 
 .form-group label {
+  display: block;
   font-size: 13px;
   font-weight: 600;
   color: #9a9abb;

--- a/src/components/SaveModal.test.tsx
+++ b/src/components/SaveModal.test.tsx
@@ -17,15 +17,15 @@ const createTask = (overrides: Partial<Task> = {}): Task => ({
 });
 
 describe('SaveModal', () => {
-  it('renders modal with task name', () => {
+  it('renders modal with task name as h2', () => {
     const task = createTask({ name: 'My Task' });
     const onSave = vi.fn();
     const onCancel = vi.fn();
 
     render(<SaveModal task={task} nextTask={null} onSave={onSave} onCancel={onCancel} />);
 
-    expect(screen.getByText('セーブポイント')).toBeInTheDocument();
-    expect(screen.getByText('「My Task」の進捗を保存します')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'My Task', level: 2 })).toBeInTheDocument();
+    expect(screen.getByText('進捗を保存します')).toBeInTheDocument();
   });
 
   it('renders save and exit button when no next task', () => {
@@ -49,7 +49,7 @@ describe('SaveModal', () => {
     expect(screen.getByText('保存して「Next Task」へ')).toBeInTheDocument();
   });
 
-  it('initializes form with existing task data', () => {
+  it('initializes form with existing task data split by newlines', () => {
     const task = createTask({
       progress: 'Existing progress',
       nextStep: 'Existing next step',
@@ -78,7 +78,7 @@ describe('SaveModal', () => {
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
 
-  it('calls onSave with form data when submitted', async () => {
+  it('calls onSave with newline-joined strings when submitted', async () => {
     const user = userEvent.setup();
     const task = createTask();
     const onSave = vi.fn();
@@ -86,9 +86,13 @@ describe('SaveModal', () => {
 
     render(<SaveModal task={task} nextTask={null} onSave={onSave} onCancel={onCancel} />);
 
-    await user.type(screen.getByPlaceholderText('現在の進捗状況を記録...'), 'New progress');
-    await user.type(screen.getByPlaceholderText('再開時に最初にやることを記録...'), 'New next step');
-    await user.type(screen.getByPlaceholderText('忘れないようにメモ...'), 'New remaining');
+    const progressInputs = screen.getAllByPlaceholderText('進捗を入力...');
+    const nextStepInputs = screen.getAllByPlaceholderText('次のステップを入力...');
+    const remainingInputs = screen.getAllByPlaceholderText('残タスクを入力...');
+
+    await user.type(progressInputs[0], 'New progress');
+    await user.type(nextStepInputs[0], 'New next step');
+    await user.type(remainingInputs[0], 'New remaining');
     await user.click(screen.getByText('保存して終了'));
 
     expect(onSave).toHaveBeenCalledWith({
@@ -96,6 +100,75 @@ describe('SaveModal', () => {
       nextStep: 'New next step',
       remaining: 'New remaining',
     });
+  });
+
+  it('adds a new list item when + 追加 button is clicked', async () => {
+    const user = userEvent.setup();
+    const task = createTask();
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
+
+    render(<SaveModal task={task} nextTask={null} onSave={onSave} onCancel={onCancel} />);
+
+    const addButtons = screen.getAllByText('+ 追加');
+    expect(screen.getAllByPlaceholderText('進捗を入力...')).toHaveLength(1);
+
+    await user.click(addButtons[0]);
+
+    expect(screen.getAllByPlaceholderText('進捗を入力...')).toHaveLength(2);
+  });
+
+  it('removes a list item when × button is clicked', async () => {
+    const user = userEvent.setup();
+    const task = createTask({ progress: 'item1\nitem2' });
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
+
+    render(<SaveModal task={task} nextTask={null} onSave={onSave} onCancel={onCancel} />);
+
+    expect(screen.getAllByPlaceholderText('進捗を入力...')).toHaveLength(2);
+
+    const removeButtons = screen.getAllByText('×');
+    await user.click(removeButtons[0]);
+
+    expect(screen.getAllByPlaceholderText('進捗を入力...')).toHaveLength(1);
+  });
+
+  it('disables remove button when only one item remains', () => {
+    const task = createTask();
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
+
+    render(<SaveModal task={task} nextTask={null} onSave={onSave} onCancel={onCancel} />);
+
+    const removeButtons = screen.getAllByText('×');
+    expect(removeButtons[0]).toBeDisabled();
+  });
+
+  it('submits multiple progress items joined by newlines', async () => {
+    const user = userEvent.setup();
+    const task = createTask();
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
+
+    render(<SaveModal task={task} nextTask={null} onSave={onSave} onCancel={onCancel} />);
+
+    const progressInputs = screen.getAllByPlaceholderText('進捗を入力...');
+    await user.type(progressInputs[0], 'Step 1');
+
+    const addButtons = screen.getAllByText('+ 追加');
+    await user.click(addButtons[0]);
+
+    const progressInputsAfter = screen.getAllByPlaceholderText('進捗を入力...');
+    await user.type(progressInputsAfter[1], 'Step 2');
+
+    await user.click(screen.getByText('保存して終了'));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        progress: 'Step 1\nStep 2',
+      })
+    );
   });
 
   it('updates progress field on change', async () => {
@@ -106,7 +179,7 @@ describe('SaveModal', () => {
 
     render(<SaveModal task={task} nextTask={null} onSave={onSave} onCancel={onCancel} />);
 
-    const progressInput = screen.getByPlaceholderText('現在の進捗状況を記録...');
+    const progressInput = screen.getAllByPlaceholderText('進捗を入力...')[0];
     await user.type(progressInput, 'Updated progress');
 
     expect(progressInput).toHaveValue('Updated progress');
@@ -120,7 +193,7 @@ describe('SaveModal', () => {
 
     render(<SaveModal task={task} nextTask={null} onSave={onSave} onCancel={onCancel} />);
 
-    const nextStepInput = screen.getByPlaceholderText('再開時に最初にやることを記録...');
+    const nextStepInput = screen.getAllByPlaceholderText('次のステップを入力...')[0];
     await user.type(nextStepInput, 'Updated next step');
 
     expect(nextStepInput).toHaveValue('Updated next step');
@@ -134,7 +207,7 @@ describe('SaveModal', () => {
 
     render(<SaveModal task={task} nextTask={null} onSave={onSave} onCancel={onCancel} />);
 
-    const remainingInput = screen.getByPlaceholderText('忘れないようにメモ...');
+    const remainingInput = screen.getAllByPlaceholderText('残タスクを入力...')[0];
     await user.type(remainingInput, 'Updated remaining');
 
     expect(remainingInput).toHaveValue('Updated remaining');

--- a/src/components/SaveModal.tsx
+++ b/src/components/SaveModal.tsx
@@ -10,13 +10,33 @@ interface SaveModalProps {
 }
 
 export function SaveModal({ task, nextTask, onSave, onCancel }: SaveModalProps) {
-  const [progress, setProgress] = useState(task.progress);
-  const [nextStep, setNextStep] = useState(task.nextStep);
-  const [remaining, setRemaining] = useState(task.remaining);
+  const [progressItems, setProgressItems] = useState<string[]>(
+    task.progress ? task.progress.split('\n').filter(Boolean) : ['']
+  );
+  const [nextStepItems, setNextStepItems] = useState<string[]>(
+    task.nextStep ? task.nextStep.split('\n').filter(Boolean) : ['']
+  );
+  const [remainingItems, setRemainingItems] = useState<string[]>(
+    task.remaining ? task.remaining.split('\n').filter(Boolean) : ['']
+  );
+
+  const handleItemChange = (setter: React.Dispatch<React.SetStateAction<string[]>>, index: number, value: string) => {
+    setter(prev => prev.map((item, i) => i === index ? value : item));
+  };
+  const handleAddItem = (setter: React.Dispatch<React.SetStateAction<string[]>>) => {
+    setter(prev => [...prev, '']);
+  };
+  const handleRemoveItem = (setter: React.Dispatch<React.SetStateAction<string[]>>, index: number) => {
+    setter(prev => prev.filter((_, i) => i !== index));
+  };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    onSave({ progress, nextStep, remaining });
+    onSave({
+      progress: progressItems.filter(Boolean).join('\n'),
+      nextStep: nextStepItems.filter(Boolean).join('\n'),
+      remaining: remainingItems.filter(Boolean).join('\n'),
+    });
   };
 
   return (
@@ -24,8 +44,8 @@ export function SaveModal({ task, nextTask, onSave, onCancel }: SaveModalProps) 
       <div className="modal save-modal">
         <div className="modal-header">
           <div className="modal-icon">💾</div>
-          <h2>セーブポイント</h2>
-          <p className="modal-subtitle">「{task.name}」の進捗を保存します</p>
+          <h2 className="modal-task-name">{task.name}</h2>
+          <p className="modal-subtitle">進捗を保存します</p>
         </div>
 
         <form onSubmit={handleSubmit}>
@@ -34,12 +54,31 @@ export function SaveModal({ task, nextTask, onSave, onCancel }: SaveModalProps) 
               <span className="label-icon">📍</span>
               どこまで進んだ？
             </label>
-            <textarea
-              value={progress}
-              onChange={(e) => setProgress(e.target.value)}
-              placeholder="現在の進捗状況を記録..."
-              rows={3}
-            />
+            <div className="list-input-group">
+              {progressItems.map((item, i) => (
+                <div key={i} className="list-input-row">
+                  <span className="list-bullet">•</span>
+                  <input
+                    type="text"
+                    value={item}
+                    onChange={(e) => handleItemChange(setProgressItems, i, e.target.value)}
+                    placeholder="進捗を入力..."
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') { e.preventDefault(); handleAddItem(setProgressItems); }
+                    }}
+                  />
+                  <button
+                    type="button"
+                    className="list-remove-btn"
+                    onClick={() => handleRemoveItem(setProgressItems, i)}
+                    disabled={progressItems.length === 1}
+                  >×</button>
+                </div>
+              ))}
+              <button type="button" className="list-add-btn" onClick={() => handleAddItem(setProgressItems)}>
+                + 追加
+              </button>
+            </div>
           </div>
 
           <div className="form-group">
@@ -47,12 +86,31 @@ export function SaveModal({ task, nextTask, onSave, onCancel }: SaveModalProps) 
               <span className="label-icon">➡️</span>
               次にやること
             </label>
-            <textarea
-              value={nextStep}
-              onChange={(e) => setNextStep(e.target.value)}
-              placeholder="再開時に最初にやることを記録..."
-              rows={2}
-            />
+            <div className="list-input-group">
+              {nextStepItems.map((item, i) => (
+                <div key={i} className="list-input-row">
+                  <span className="list-bullet">•</span>
+                  <input
+                    type="text"
+                    value={item}
+                    onChange={(e) => handleItemChange(setNextStepItems, i, e.target.value)}
+                    placeholder="次のステップを入力..."
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') { e.preventDefault(); handleAddItem(setNextStepItems); }
+                    }}
+                  />
+                  <button
+                    type="button"
+                    className="list-remove-btn"
+                    onClick={() => handleRemoveItem(setNextStepItems, i)}
+                    disabled={nextStepItems.length === 1}
+                  >×</button>
+                </div>
+              ))}
+              <button type="button" className="list-add-btn" onClick={() => handleAddItem(setNextStepItems)}>
+                + 追加
+              </button>
+            </div>
           </div>
 
           <div className="form-group">
@@ -60,12 +118,31 @@ export function SaveModal({ task, nextTask, onSave, onCancel }: SaveModalProps) 
               <span className="label-icon">📝</span>
               残タスク・後回しにすること
             </label>
-            <textarea
-              value={remaining}
-              onChange={(e) => setRemaining(e.target.value)}
-              placeholder="忘れないようにメモ..."
-              rows={2}
-            />
+            <div className="list-input-group">
+              {remainingItems.map((item, i) => (
+                <div key={i} className="list-input-row">
+                  <span className="list-bullet">•</span>
+                  <input
+                    type="text"
+                    value={item}
+                    onChange={(e) => handleItemChange(setRemainingItems, i, e.target.value)}
+                    placeholder="残タスクを入力..."
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') { e.preventDefault(); handleAddItem(setRemainingItems); }
+                    }}
+                  />
+                  <button
+                    type="button"
+                    className="list-remove-btn"
+                    onClick={() => handleRemoveItem(setRemainingItems, i)}
+                    disabled={remainingItems.length === 1}
+                  >×</button>
+                </div>
+              ))}
+              <button type="button" className="list-add-btn" onClick={() => handleAddItem(setRemainingItems)}>
+                + 追加
+              </button>
+            </div>
           </div>
 
           <div className="modal-actions">


### PR DESCRIPTION
## 変更内容

- **ヘッダー構造の変更**: サービス名（「セーブポイント」「ロード」「タスク完了」）を削除し、タスク名を `h2` で大きく表示するよう変更。サブタイトルに各モーダルの用途テキストを表示。
- **モーダルサイズの拡大**: `max-width: 720px`、`padding: 32px`、`max-height: 92vh` に拡大。
- **リスト形式の入力 UI**: SaveModal / CompleteModal の各 `<textarea>` をリスト形式の入力（`+追加` / `×削除` ボタン付き）に変更。状態は `string[]` で管理し、送信時に `\n` 区切りで結合。
- **LoadModal のリスト表示**: 読み取り専用の進捗データを `<p>` から `<ul>/<li>` 形式に変更し、`\n` 区切りデータを複数アイテムとして表示。
- **CSS の追加**: `.modal-task-name`、`.list-input-group`、`.list-input-row`、`.list-bullet`、`.list-remove-btn`、`.list-add-btn`、`.save-section-list` などの新スタイルを追加。
- **テストの更新**: 新 UI に合わせてアサーションを更新し、リスト追加・削除・複数アイテムの `\n` 結合送信テストを追加。

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)