### PR TITLE
feat: 完了ボタンを中断ボタンから分離 (close #16)

### DIFF
--- a/src/components/ActiveTaskBanner.css
+++ b/src/components/ActiveTaskBanner.css
@@ -67,6 +67,8 @@
 
 .banner-actions {
   display: flex;
+  justify-content: space-between;
+  align-items: center;
   gap: 8px;
 }
 
@@ -86,6 +88,8 @@
 .banner-btn.pause-btn {
   background: #2a3a4a;
   color: #aaccee;
+  font-size: 14px;
+  padding: 10px 20px;
 }
 
 .banner-btn.pause-btn:hover {
@@ -93,10 +97,14 @@
 }
 
 .banner-btn.complete-btn {
-  background: #1a3a2a;
+  background: transparent;
   color: #4aff4a;
+  font-size: 12px;
+  padding: 6px 12px;
+  border: 1px solid currentColor;
+  opacity: 0.7;
 }
 
 .banner-btn.complete-btn:hover {
-  background: #2a4a3a;
+  opacity: 1;
 }


### PR DESCRIPTION
## Summary

- `banner-actions` に `justify-content: space-between` を設定し、「中断」と「完了」ボタンを両端配置に変更
- 「中断」ボタンをプライマリアクションとして目立つよう `font-size: 14px` / `padding: 10px 20px` に拡大
- 「完了」ボタンをセカンダリアクションとして `background: transparent`、アウトラインスタイル（`border: 1px solid currentColor`）、`opacity: 0.7` で控えめな表示に変更

## Test plan

- [ ] `pnpm test` で全70テストがパスすることを確認
- [ ] 「中断」ボタンがバナー左端に、「完了」ボタンが右端に表示されること
- [ ] 「中断」ボタンクリックで `onPause` が呼ばれること
- [ ] 「完了」ボタンクリックで `onComplete` が呼ばれること

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)