### PR TITLE
feat: キーボードショートカット対応 (close #19)

### DIFF
--- a/src/components/AddTaskForm.test.tsx
+++ b/src/components/AddTaskForm.test.tsx
@@ -130,4 +130,32 @@ describe('AddTaskForm', () => {
 
     expect(onAdd).not.toHaveBeenCalled();
   });
+
+  it('collapses form when Escape key is pressed while expanded', async () => {
+    const user = userEvent.setup();
+    const onAdd = vi.fn();
+
+    render(<AddTaskForm onAdd={onAdd} />);
+
+    await user.click(screen.getByText('新しいタスクを追加'));
+    expect(screen.getByPlaceholderText('タスク名を入力...')).toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+
+    expect(screen.getByText('新しいタスクを追加')).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('タスク名を入力...')).not.toBeInTheDocument();
+  });
+
+  it('does not collapse form when Escape key is pressed while not expanded', async () => {
+    const user = userEvent.setup();
+    const onAdd = vi.fn();
+
+    render(<AddTaskForm onAdd={onAdd} />);
+
+    // Don't expand the form - just press Escape
+    await user.keyboard('{Escape}');
+
+    // Form should still show the trigger button
+    expect(screen.getByText('新しいタスクを追加')).toBeInTheDocument();
+  });
 });

--- a/src/components/AddTaskForm.tsx
+++ b/src/components/AddTaskForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import './AddTaskForm.css';
 
 interface AddTaskFormProps {
@@ -8,6 +8,17 @@ interface AddTaskFormProps {
 export function AddTaskForm({ onAdd }: AddTaskFormProps) {
   const [name, setName] = useState('');
   const [isExpanded, setIsExpanded] = useState(false);
+
+  useEffect(() => {
+    if (!isExpanded) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setIsExpanded(false);
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [isExpanded]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/components/CompleteModal.test.tsx
+++ b/src/components/CompleteModal.test.tsx
@@ -50,7 +50,7 @@ describe('CompleteModal', () => {
 
     render(<CompleteModal task={task} onComplete={onComplete} onCancel={onCancel} />);
 
-    await user.click(screen.getByText('キャンセル'));
+    await user.click(screen.getByRole('button', { name: /キャンセル/ }));
 
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
@@ -65,7 +65,7 @@ describe('CompleteModal', () => {
 
     await user.type(screen.getByPlaceholderText('完了時の状況や成果を記録...'), 'Completion notes');
     await user.type(screen.getByPlaceholderText('今後のために残しておきたいメモ...'), 'Future notes');
-    await user.click(screen.getByText('完了にする'));
+    await user.click(screen.getByRole('button', { name: /完了にする/ }));
 
     expect(onComplete).toHaveBeenCalledWith({
       progress: 'Completion notes',
@@ -110,12 +110,51 @@ describe('CompleteModal', () => {
 
     render(<CompleteModal task={task} onComplete={onComplete} onCancel={onCancel} />);
 
-    await user.click(screen.getByText('完了にする'));
+    await user.click(screen.getByRole('button', { name: /完了にする/ }));
 
     expect(onComplete).toHaveBeenCalledWith(
       expect.objectContaining({
         nextStep: '',
       })
     );
+  });
+
+  it('calls onCancel when Escape key is pressed', async () => {
+    const user = userEvent.setup();
+    const task = createTask();
+    const onComplete = vi.fn();
+    const onCancel = vi.fn();
+
+    render(<CompleteModal task={task} onComplete={onComplete} onCancel={onCancel} />);
+
+    await user.keyboard('{Escape}');
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('submits form when Cmd+Enter is pressed', async () => {
+    const user = userEvent.setup();
+    const task = createTask();
+    const onComplete = vi.fn();
+    const onCancel = vi.fn();
+
+    render(<CompleteModal task={task} onComplete={onComplete} onCancel={onCancel} />);
+
+    await user.keyboard('{Meta>}{Enter}{/Meta}');
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('submits form when Ctrl+Enter is pressed', async () => {
+    const user = userEvent.setup();
+    const task = createTask();
+    const onComplete = vi.fn();
+    const onCancel = vi.fn();
+
+    render(<CompleteModal task={task} onComplete={onComplete} onCancel={onCancel} />);
+
+    await user.keyboard('{Control>}{Enter}{/Control}');
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/CompleteModal.tsx
+++ b/src/components/CompleteModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { Task, SavePointData } from '../types';
+import { useModalKeyboard } from '../hooks/useModalKeyboard';
 import './Modal.css';
 
 interface CompleteModalProps {
@@ -12,10 +13,16 @@ export function CompleteModal({ task, onComplete, onCancel }: CompleteModalProps
   const [progress, setProgress] = useState(task.progress);
   const [remaining, setRemaining] = useState(task.remaining);
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleConfirm = () => {
     onComplete({ progress, nextStep: '', remaining });
   };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    handleConfirm();
+  };
+
+  useModalKeyboard({ onConfirm: handleConfirm, onCancel });
 
   return (
     <div className="modal-overlay">
@@ -55,10 +62,10 @@ export function CompleteModal({ task, onComplete, onCancel }: CompleteModalProps
 
           <div className="modal-actions">
             <button type="button" className="btn btn-secondary" onClick={onCancel}>
-              キャンセル
+              キャンセル<span className="shortcut-hint" aria-hidden="true">Esc</span>
             </button>
             <button type="submit" className="btn btn-primary">
-              完了にする
+              完了にする<span className="shortcut-hint" aria-hidden="true">⌘+Enter</span>
             </button>
           </div>
         </form>

--- a/src/components/LoadModal.test.tsx
+++ b/src/components/LoadModal.test.tsx
@@ -107,7 +107,7 @@ describe('LoadModal', () => {
 
     render(<LoadModal task={task} onLoad={onLoad} onCancel={onCancel} />);
 
-    await user.click(screen.getByText('キャンセル'));
+    await user.click(screen.getByRole('button', { name: /キャンセル/ }));
 
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
@@ -120,7 +120,7 @@ describe('LoadModal', () => {
 
     render(<LoadModal task={task} onLoad={onLoad} onCancel={onCancel} />);
 
-    await user.click(screen.getByText('再開する'));
+    await user.click(screen.getByRole('button', { name: /再開する/ }));
 
     expect(onLoad).toHaveBeenCalledTimes(1);
   });
@@ -156,5 +156,44 @@ describe('LoadModal', () => {
 
     expect(screen.getByText('前回の進捗')).toBeInTheDocument();
     expect(screen.queryByText('残タスク')).not.toBeInTheDocument();
+  });
+
+  it('calls onCancel when Escape key is pressed', async () => {
+    const user = userEvent.setup();
+    const task = createTask();
+    const onLoad = vi.fn();
+    const onCancel = vi.fn();
+
+    render(<LoadModal task={task} onLoad={onLoad} onCancel={onCancel} />);
+
+    await user.keyboard('{Escape}');
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onLoad when Cmd+Enter is pressed', async () => {
+    const user = userEvent.setup();
+    const task = createTask();
+    const onLoad = vi.fn();
+    const onCancel = vi.fn();
+
+    render(<LoadModal task={task} onLoad={onLoad} onCancel={onCancel} />);
+
+    await user.keyboard('{Meta>}{Enter}{/Meta}');
+
+    expect(onLoad).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onLoad when Ctrl+Enter is pressed', async () => {
+    const user = userEvent.setup();
+    const task = createTask();
+    const onLoad = vi.fn();
+    const onCancel = vi.fn();
+
+    render(<LoadModal task={task} onLoad={onLoad} onCancel={onCancel} />);
+
+    await user.keyboard('{Control>}{Enter}{/Control}');
+
+    expect(onLoad).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/LoadModal.tsx
+++ b/src/components/LoadModal.tsx
@@ -1,4 +1,5 @@
 import type { Task } from '../types';
+import { useModalKeyboard } from '../hooks/useModalKeyboard';
 import './Modal.css';
 
 interface LoadModalProps {
@@ -10,6 +11,8 @@ interface LoadModalProps {
 export function LoadModal({ task, onLoad, onCancel }: LoadModalProps) {
   const hasProgress = task.progress || task.nextStep || task.remaining;
   const lastUpdated = new Date(task.updatedAt).toLocaleString('ja-JP');
+
+  useModalKeyboard({ onConfirm: onLoad, onCancel });
 
   return (
     <div className="modal-overlay">
@@ -56,10 +59,10 @@ export function LoadModal({ task, onLoad, onCancel }: LoadModalProps) {
 
         <div className="modal-actions">
           <button type="button" className="btn btn-secondary" onClick={onCancel}>
-            キャンセル
+            キャンセル<span className="shortcut-hint" aria-hidden="true">Esc</span>
           </button>
           <button type="button" className="btn btn-primary" onClick={onLoad}>
-            再開する
+            再開する<span className="shortcut-hint" aria-hidden="true">⌘+Enter</span>
           </button>
         </div>
       </div>

--- a/src/components/Modal.css
+++ b/src/components/Modal.css
@@ -200,3 +200,11 @@
 .complete-modal .modal-header {
   color: #4aff4a;
 }
+
+/* Keyboard shortcut hints */
+.shortcut-hint {
+  font-size: 11px;
+  opacity: 0.6;
+  margin-left: 8px;
+  font-family: monospace;
+}

--- a/src/components/SaveModal.test.tsx
+++ b/src/components/SaveModal.test.tsx
@@ -35,7 +35,7 @@ describe('SaveModal', () => {
 
     render(<SaveModal task={task} nextTask={null} onSave={onSave} onCancel={onCancel} />);
 
-    expect(screen.getByText('保存して終了')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /保存して終了/ })).toBeInTheDocument();
   });
 
   it('renders save and switch button when next task exists', () => {
@@ -46,7 +46,7 @@ describe('SaveModal', () => {
 
     render(<SaveModal task={task} nextTask={nextTask} onSave={onSave} onCancel={onCancel} />);
 
-    expect(screen.getByText('保存して「Next Task」へ')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /保存して「Next Task」へ/ })).toBeInTheDocument();
   });
 
   it('initializes form with existing task data', () => {
@@ -73,7 +73,7 @@ describe('SaveModal', () => {
 
     render(<SaveModal task={task} nextTask={null} onSave={onSave} onCancel={onCancel} />);
 
-    await user.click(screen.getByText('キャンセル'));
+    await user.click(screen.getByRole('button', { name: /キャンセル/ }));
 
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
@@ -89,7 +89,7 @@ describe('SaveModal', () => {
     await user.type(screen.getByPlaceholderText('現在の進捗状況を記録...'), 'New progress');
     await user.type(screen.getByPlaceholderText('再開時に最初にやることを記録...'), 'New next step');
     await user.type(screen.getByPlaceholderText('忘れないようにメモ...'), 'New remaining');
-    await user.click(screen.getByText('保存して終了'));
+    await user.click(screen.getByRole('button', { name: /保存して終了/ }));
 
     expect(onSave).toHaveBeenCalledWith({
       progress: 'New progress',
@@ -138,5 +138,44 @@ describe('SaveModal', () => {
     await user.type(remainingInput, 'Updated remaining');
 
     expect(remainingInput).toHaveValue('Updated remaining');
+  });
+
+  it('calls onCancel when Escape key is pressed', async () => {
+    const user = userEvent.setup();
+    const task = createTask();
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
+
+    render(<SaveModal task={task} nextTask={null} onSave={onSave} onCancel={onCancel} />);
+
+    await user.keyboard('{Escape}');
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('submits form when Cmd+Enter is pressed', async () => {
+    const user = userEvent.setup();
+    const task = createTask();
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
+
+    render(<SaveModal task={task} nextTask={null} onSave={onSave} onCancel={onCancel} />);
+
+    await user.keyboard('{Meta>}{Enter}{/Meta}');
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+
+  it('submits form when Ctrl+Enter is pressed', async () => {
+    const user = userEvent.setup();
+    const task = createTask();
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
+
+    render(<SaveModal task={task} nextTask={null} onSave={onSave} onCancel={onCancel} />);
+
+    await user.keyboard('{Control>}{Enter}{/Control}');
+
+    expect(onSave).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/SaveModal.tsx
+++ b/src/components/SaveModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { Task, SavePointData } from '../types';
+import { useModalKeyboard } from '../hooks/useModalKeyboard';
 import './Modal.css';
 
 interface SaveModalProps {
@@ -14,10 +15,16 @@ export function SaveModal({ task, nextTask, onSave, onCancel }: SaveModalProps) 
   const [nextStep, setNextStep] = useState(task.nextStep);
   const [remaining, setRemaining] = useState(task.remaining);
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleConfirm = () => {
     onSave({ progress, nextStep, remaining });
   };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    handleConfirm();
+  };
+
+  useModalKeyboard({ onConfirm: handleConfirm, onCancel });
 
   return (
     <div className="modal-overlay">
@@ -70,10 +77,10 @@ export function SaveModal({ task, nextTask, onSave, onCancel }: SaveModalProps) 
 
           <div className="modal-actions">
             <button type="button" className="btn btn-secondary" onClick={onCancel}>
-              キャンセル
+              キャンセル<span className="shortcut-hint" aria-hidden="true">Esc</span>
             </button>
             <button type="submit" className="btn btn-primary">
-              {nextTask ? `保存して「${nextTask.name}」へ` : '保存して終了'}
+              {nextTask ? `保存して「${nextTask.name}」へ` : '保存して終了'}<span className="shortcut-hint" aria-hidden="true">⌘+Enter</span>
             </button>
           </div>
         </form>

--- a/src/hooks/useModalKeyboard.test.ts
+++ b/src/hooks/useModalKeyboard.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useModalKeyboard } from './useModalKeyboard';
+
+describe('useModalKeyboard', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls onCancel when Escape is pressed', () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+
+    renderHook(() => useModalKeyboard({ onConfirm, onCancel }));
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('calls onConfirm when Cmd+Enter is pressed', () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+
+    renderHook(() => useModalKeyboard({ onConfirm, onCancel }));
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', metaKey: true, bubbles: true }));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it('calls onConfirm when Ctrl+Enter is pressed', () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+
+    renderHook(() => useModalKeyboard({ onConfirm, onCancel }));
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', ctrlKey: true, bubbles: true }));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when enabled is false', () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+
+    renderHook(() => useModalKeyboard({ onConfirm, onCancel, enabled: false }));
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', metaKey: true, bubbles: true }));
+
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('cleans up event listener on unmount', () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+
+    const { unmount } = renderHook(() => useModalKeyboard({ onConfirm, onCancel }));
+
+    unmount();
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', metaKey: true, bubbles: true }));
+
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useModalKeyboard.ts
+++ b/src/hooks/useModalKeyboard.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+
+interface UseModalKeyboardOptions {
+  onConfirm: () => void;
+  onCancel: () => void;
+  enabled?: boolean;
+}
+
+export function useModalKeyboard({ onConfirm, onCancel, enabled = true }: UseModalKeyboardOptions) {
+  useEffect(() => {
+    if (!enabled) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onCancel();
+      }
+      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        onConfirm();
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onConfirm, onCancel, enabled]);
+}


### PR DESCRIPTION
## Summary

- `useModalKeyboard` カスタムフックを新規作成し、Escapeキーでキャンセル・Cmd/Ctrl+Enterで確定の共通キーボード操作を実装
- SaveModal、LoadModal、CompleteModal に `useModalKeyboard` フックを適用
- AddTaskForm に `useEffect` を使ったEscapeキーでフォームを閉じる機能を追加
- Modal.css に `.shortcut-hint` スタイルを追加し、ボタン上にショートカットヒントを表示（`aria-hidden="true"` でアクセシビリティに配慮）
- 全モーダルのテストを `getByRole` ベースに更新し、キーボードショートカットのテストを追加（合計94テスト全パス）

## Test plan

- [ ] pnpm test で全94テストがパスすることを確認
- [ ] SaveModal: Escapeキーでキャンセル、Cmd+Enter/Ctrl+Enterで保存が動作することを確認
- [ ] LoadModal: Escapeキーでキャンセル、Cmd+Enter/Ctrl+Enterで再開が動作することを確認
- [ ] CompleteModal: Escapeキーでキャンセル、Cmd+Enter/Ctrl+Enterで完了が動作することを確認
- [ ] AddTaskForm: フォーム展開中にEscapeキーでフォームが閉じることを確認

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)