### PR TITLE
feat: タスク更新履歴のツリービュー (close #18)

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -24,6 +24,19 @@ db.exec(`
   )
 `);
 
+db.exec(`
+  CREATE TABLE IF NOT EXISTS task_history (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id    TEXT NOT NULL,
+    status     TEXT NOT NULL,
+    progress   TEXT NOT NULL DEFAULT '',
+    next_step  TEXT NOT NULL DEFAULT '',
+    remaining  TEXT NOT NULL DEFAULT '',
+    saved_at   INTEGER NOT NULL,
+    FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
+  )
+`);
+
 export interface TaskRow {
   id: string;
   name: string;
@@ -56,5 +69,37 @@ export function rowToTask(row: TaskRow): Task {
     progress: row.progress,
     nextStep: row.next_step,
     remaining: row.remaining,
+  };
+}
+
+export interface HistoryRow {
+  id: number;
+  task_id: string;
+  status: string;
+  progress: string;
+  next_step: string;
+  remaining: string;
+  saved_at: number;
+}
+
+export interface TaskHistory {
+  id: number;
+  taskId: string;
+  status: 'active' | 'paused' | 'completed';
+  progress: string;
+  nextStep: string;
+  remaining: string;
+  savedAt: number;
+}
+
+export function rowToHistory(row: HistoryRow): TaskHistory {
+  return {
+    id: row.id,
+    taskId: row.task_id,
+    status: row.status as TaskHistory['status'],
+    progress: row.progress,
+    nextStep: row.next_step,
+    remaining: row.remaining,
+    savedAt: row.saved_at,
   };
 }

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -69,31 +69,42 @@ tasks.put('/:id', async (c) => {
 
   values.push(id);
 
-  const stmt = db.prepare(`UPDATE tasks SET ${updates.join(', ')} WHERE id = ?`);
-  stmt.run(...values);
-
-  const row = db.prepare('SELECT * FROM tasks WHERE id = ?').get(id) as TaskRow;
-
-  // 更新内容に応じて履歴を記録
+  // 更新内容に応じて履歴を記録するかどうか
   const shouldRecord =
     body.status !== undefined ||
     body.progress !== undefined ||
     body.nextStep !== undefined ||
     body.remaining !== undefined;
 
-  if (shouldRecord) {
-    db.prepare(`
-      INSERT INTO task_history (task_id, status, progress, next_step, remaining, saved_at)
-      VALUES (?, ?, ?, ?, ?, ?)
-    `).run(row.id, row.status, row.progress, row.next_step, row.remaining, Date.now());
-  }
+  const updateAndRecord = db.transaction(() => {
+    const stmt = db.prepare(`UPDATE tasks SET ${updates.join(', ')} WHERE id = ?`);
+    stmt.run(...values);
 
+    const row = db.prepare('SELECT * FROM tasks WHERE id = ?').get(id) as TaskRow;
+
+    if (shouldRecord) {
+      db.prepare(`
+        INSERT INTO task_history (task_id, status, progress, next_step, remaining, saved_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `).run(row.id, row.status, row.progress, row.next_step, row.remaining, Date.now());
+    }
+
+    return row;
+  });
+
+  const row = updateAndRecord();
   return c.json(rowToTask(row));
 });
 
 // GET /api/tasks/:id/history - タスク履歴取得
 tasks.get('/:id/history', (c) => {
   const id = c.req.param('id');
+
+  const existing = db.prepare('SELECT * FROM tasks WHERE id = ?').get(id) as TaskRow | undefined;
+  if (!existing) {
+    return c.json({ error: 'Task not found' }, 404);
+  }
+
   const rows = db.prepare(
     'SELECT * FROM task_history WHERE task_id = ? ORDER BY saved_at DESC'
   ).all(id) as HistoryRow[];

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { db, rowToTask, type TaskRow, type Task } from '../db.js';
+import { db, rowToTask, rowToHistory, type TaskRow, type Task, type HistoryRow } from '../db.js';
 
 const tasks = new Hono();
 
@@ -73,7 +73,31 @@ tasks.put('/:id', async (c) => {
   stmt.run(...values);
 
   const row = db.prepare('SELECT * FROM tasks WHERE id = ?').get(id) as TaskRow;
+
+  // 更新内容に応じて履歴を記録
+  const shouldRecord =
+    body.status !== undefined ||
+    body.progress !== undefined ||
+    body.nextStep !== undefined ||
+    body.remaining !== undefined;
+
+  if (shouldRecord) {
+    db.prepare(`
+      INSERT INTO task_history (task_id, status, progress, next_step, remaining, saved_at)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run(row.id, row.status, row.progress, row.next_step, row.remaining, Date.now());
+  }
+
   return c.json(rowToTask(row));
+});
+
+// GET /api/tasks/:id/history - タスク履歴取得
+tasks.get('/:id/history', (c) => {
+  const id = c.req.param('id');
+  const rows = db.prepare(
+    'SELECT * FROM task_history WHERE task_id = ? ORDER BY saved_at DESC'
+  ).all(id) as HistoryRow[];
+  return c.json(rows.map(rowToHistory));
 });
 
 // DELETE /api/tasks/:id - タスク削除

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,13 +9,15 @@ import {
   AddTaskForm,
   ActiveTaskBanner,
 } from './components';
+import { TaskHistoryModal } from './components/TaskHistoryModal';
 import './App.css';
 
 type ModalState =
   | { type: 'none' }
   | { type: 'save'; nextTask: Task | null }
   | { type: 'load'; task: Task }
-  | { type: 'complete'; task: Task };
+  | { type: 'complete'; task: Task }
+  | { type: 'history'; task: Task };
 
 function App() {
   const {
@@ -26,6 +28,7 @@ function App() {
     deleteTask,
     saveAndSwitch,
     completeTask,
+    fetchHistory,
   } = useTasks();
 
   const [modal, setModal] = useState<ModalState>({ type: 'none' });
@@ -50,6 +53,10 @@ function App() {
 
   const handleCompleteTask = (task: Task) => {
     setModal({ type: 'complete', task });
+  };
+
+  const handleHistory = (task: Task) => {
+    setModal({ type: 'history', task });
   };
 
   const handleSave = (data: SavePointData) => {
@@ -114,6 +121,7 @@ function App() {
             onSelect={handleSelectTask}
             onComplete={handleCompleteTask}
             onDelete={handleDelete}
+            onHistory={handleHistory}
           />
         </div>
       </main>
@@ -140,6 +148,14 @@ function App() {
           task={modal.task}
           onComplete={handleComplete}
           onCancel={() => setModal({ type: 'none' })}
+        />
+      )}
+
+      {modal.type === 'history' && (
+        <TaskHistoryModal
+          task={modal.task}
+          fetchHistory={fetchHistory}
+          onClose={() => setModal({ type: 'none' })}
         />
       )}
     </div>

--- a/src/components/TaskHistoryModal.css
+++ b/src/components/TaskHistoryModal.css
@@ -1,0 +1,98 @@
+.history-modal {
+  max-width: 560px;
+}
+
+.history-loading {
+  text-align: center;
+  padding: 32px;
+  color: #8a8aaa;
+  font-size: 14px;
+}
+
+.history-empty {
+  text-align: center;
+  padding: 32px;
+  color: #6a6a8a;
+  font-size: 14px;
+}
+
+.history-tree {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  margin-bottom: 8px;
+}
+
+.history-tree-node {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.history-tree-line-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex-shrink: 0;
+  width: 16px;
+  padding-top: 6px;
+}
+
+.history-tree-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #4a4aff;
+  flex-shrink: 0;
+  border: 2px solid #6a6aff;
+}
+
+.history-tree-line {
+  width: 2px;
+  flex: 1;
+  min-height: 16px;
+  background: #3a3a5a;
+  margin-top: 4px;
+}
+
+.history-entry {
+  flex: 1;
+  min-width: 0;
+  padding-bottom: 16px;
+}
+
+.history-entry-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.history-status-icon {
+  font-size: 14px;
+  flex-shrink: 0;
+}
+
+.history-status-label {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  color: #8a8aaa;
+  font-weight: 600;
+}
+
+.history-timestamp {
+  margin-left: auto;
+  font-size: 12px;
+  color: #5a5a7a;
+  flex-shrink: 0;
+}
+
+.history-entry-body {
+  background: #0f0f1a;
+  border-radius: 8px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}

--- a/src/components/TaskHistoryModal.test.tsx
+++ b/src/components/TaskHistoryModal.test.tsx
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TaskHistoryModal } from './TaskHistoryModal';
+import type { Task, TaskHistoryEntry } from '../types';
+
+const createTask = (overrides: Partial<Task> = {}): Task => ({
+  id: 'task-1',
+  name: 'Test Task',
+  status: 'paused',
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
+  progress: '',
+  nextStep: '',
+  remaining: '',
+  ...overrides,
+});
+
+const createHistoryEntry = (overrides: Partial<TaskHistoryEntry> = {}): TaskHistoryEntry => ({
+  id: 1,
+  taskId: 'task-1',
+  status: 'paused',
+  progress: 'Progress text',
+  nextStep: 'Next step text',
+  remaining: 'Remaining text',
+  savedAt: new Date('2024-03-15T10:30:00').getTime(),
+  ...overrides,
+});
+
+describe('TaskHistoryModal', () => {
+  it('shows loading state initially', () => {
+    const task = createTask();
+    const fetchHistory = vi.fn(() => new Promise<TaskHistoryEntry[]>(() => {}));
+    const onClose = vi.fn();
+
+    render(
+      <TaskHistoryModal
+        task={task}
+        fetchHistory={fetchHistory}
+        onClose={onClose}
+      />
+    );
+
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+  });
+
+  it('shows task name in subtitle', async () => {
+    const task = createTask({ name: 'My Task' });
+    const fetchHistory = vi.fn().mockResolvedValue([]);
+    const onClose = vi.fn();
+
+    render(
+      <TaskHistoryModal
+        task={task}
+        fetchHistory={fetchHistory}
+        onClose={onClose}
+      />
+    );
+
+    expect(screen.getByText('My Task')).toBeInTheDocument();
+  });
+
+  it('shows empty state when history is empty', async () => {
+    const task = createTask();
+    const fetchHistory = vi.fn().mockResolvedValue([]);
+    const onClose = vi.fn();
+
+    render(
+      <TaskHistoryModal
+        task={task}
+        fetchHistory={fetchHistory}
+        onClose={onClose}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('まだ更新履歴がありません')).toBeInTheDocument();
+    });
+  });
+
+  it('renders history entries when history is available', async () => {
+    const task = createTask();
+    const entry = createHistoryEntry({
+      progress: 'Did this thing',
+      nextStep: 'Next do that',
+      remaining: 'Still need to do X',
+    });
+    const fetchHistory = vi.fn().mockResolvedValue([entry]);
+    const onClose = vi.fn();
+
+    render(
+      <TaskHistoryModal
+        task={task}
+        fetchHistory={fetchHistory}
+        onClose={onClose}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Did this thing')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Next do that')).toBeInTheDocument();
+    expect(screen.getByText('Still need to do X')).toBeInTheDocument();
+  });
+
+  it('renders status labels for history entries', async () => {
+    const task = createTask();
+    const entries = [
+      createHistoryEntry({ id: 1, status: 'paused', savedAt: Date.now() - 2000 }),
+      createHistoryEntry({ id: 2, status: 'active', savedAt: Date.now() - 1000 }),
+      createHistoryEntry({ id: 3, status: 'completed', savedAt: Date.now() }),
+    ];
+    const fetchHistory = vi.fn().mockResolvedValue(entries);
+    const onClose = vi.fn();
+
+    render(
+      <TaskHistoryModal
+        task={task}
+        fetchHistory={fetchHistory}
+        onClose={onClose}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByText('中断').length).toBeGreaterThan(0);
+    });
+
+    expect(screen.getByText('進行中')).toBeInTheDocument();
+    expect(screen.getByText('完了')).toBeInTheDocument();
+  });
+
+  it('calls onClose when close button is clicked', async () => {
+    const user = userEvent.setup();
+    const task = createTask();
+    const fetchHistory = vi.fn().mockResolvedValue([]);
+    const onClose = vi.fn();
+
+    render(
+      <TaskHistoryModal
+        task={task}
+        fetchHistory={fetchHistory}
+        onClose={onClose}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('閉じる')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText('閉じる'));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when overlay is clicked', async () => {
+    const user = userEvent.setup();
+    const task = createTask();
+    const fetchHistory = vi.fn().mockResolvedValue([]);
+    const onClose = vi.fn();
+
+    render(
+      <TaskHistoryModal
+        task={task}
+        fetchHistory={fetchHistory}
+        onClose={onClose}
+      />
+    );
+
+    const overlay = document.querySelector('.modal-overlay') as HTMLElement;
+    await user.click(overlay);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls fetchHistory with the task id on mount', async () => {
+    const task = createTask({ id: 'task-abc-123' });
+    const fetchHistory = vi.fn().mockResolvedValue([]);
+    const onClose = vi.fn();
+
+    render(
+      <TaskHistoryModal
+        task={task}
+        fetchHistory={fetchHistory}
+        onClose={onClose}
+      />
+    );
+
+    await waitFor(() => {
+      expect(fetchHistory).toHaveBeenCalledWith('task-abc-123');
+    });
+  });
+
+  it('does not show sections for empty fields in history entry', async () => {
+    const task = createTask();
+    const entry = createHistoryEntry({
+      progress: '',
+      nextStep: '',
+      remaining: '',
+    });
+    const fetchHistory = vi.fn().mockResolvedValue([entry]);
+    const onClose = vi.fn();
+
+    render(
+      <TaskHistoryModal
+        task={task}
+        fetchHistory={fetchHistory}
+        onClose={onClose}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('どこまで進んだか')).not.toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('次のステップ')).not.toBeInTheDocument();
+    expect(screen.queryByText('残っている課題')).not.toBeInTheDocument();
+  });
+
+  it('shows modal title', () => {
+    const task = createTask();
+    const fetchHistory = vi.fn().mockResolvedValue([]);
+    const onClose = vi.fn();
+
+    render(
+      <TaskHistoryModal
+        task={task}
+        fetchHistory={fetchHistory}
+        onClose={onClose}
+      />
+    );
+
+    expect(screen.getByText('更新履歴')).toBeInTheDocument();
+  });
+});

--- a/src/components/TaskHistoryModal.tsx
+++ b/src/components/TaskHistoryModal.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useState } from 'react';
+import type { Task, TaskHistoryEntry } from '../types';
+import './TaskHistoryModal.css';
+
+interface TaskHistoryModalProps {
+  task: Task;
+  fetchHistory: (taskId: string) => Promise<TaskHistoryEntry[]>;
+  onClose: () => void;
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  active: '進行中',
+  paused: '中断',
+  completed: '完了',
+};
+
+const STATUS_ICON: Record<string, string> = {
+  active: '▶️',
+  paused: '⏸️',
+  completed: '✅',
+};
+
+function formatDateTime(timestamp: number): string {
+  const date = new Date(timestamp);
+  return date.toLocaleString('ja-JP', {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export function TaskHistoryModal({ task, fetchHistory, onClose }: TaskHistoryModalProps) {
+  const [history, setHistory] = useState<TaskHistoryEntry[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    fetchHistory(task.id).then((entries) => {
+      if (!cancelled) {
+        setHistory(entries);
+        setIsLoading(false);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [task.id, fetchHistory]);
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal history-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-header">
+          <div className="modal-icon">📜</div>
+          <h2>更新履歴</h2>
+          <p className="modal-subtitle">{task.name}</p>
+        </div>
+
+        {isLoading ? (
+          <div className="history-loading">読み込み中...</div>
+        ) : history.length === 0 ? (
+          <div className="history-empty">
+            <p>まだ更新履歴がありません</p>
+          </div>
+        ) : (
+          <div className="history-tree">
+            {history.map((entry, index) => (
+              <div key={entry.id} className="history-tree-node">
+                <div className="history-tree-line-container">
+                  <div className="history-tree-dot" />
+                  {index < history.length - 1 && <div className="history-tree-line" />}
+                </div>
+                <div className="history-entry">
+                  <div className="history-entry-header">
+                    <span className="history-status-icon">{STATUS_ICON[entry.status] ?? '⏸️'}</span>
+                    <span className="history-status-label">{STATUS_LABEL[entry.status] ?? entry.status}</span>
+                    <span className="history-timestamp">{formatDateTime(entry.savedAt)}</span>
+                  </div>
+                  {(entry.progress || entry.nextStep || entry.remaining) && (
+                    <div className="history-entry-body">
+                      {entry.progress && (
+                        <div className="save-section">
+                          <h3>どこまで進んだか</h3>
+                          <p>{entry.progress}</p>
+                        </div>
+                      )}
+                      {entry.nextStep && (
+                        <div className="save-section highlight">
+                          <h3>次のステップ</h3>
+                          <p>{entry.nextStep}</p>
+                        </div>
+                      )}
+                      {entry.remaining && (
+                        <div className="save-section">
+                          <h3>残っている課題</h3>
+                          <p>{entry.remaining}</p>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="modal-actions">
+          <button className="btn btn-secondary" onClick={onClose}>
+            閉じる
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TaskList.css
+++ b/src/components/TaskList.css
@@ -150,6 +150,15 @@
   background: #2a4a3a;
 }
 
+.history-btn {
+  background: #1a2a3a;
+  color: #8aaaff;
+}
+
+.history-btn:hover {
+  background: #2a3a4a;
+}
+
 .delete-btn {
   background: #3a1a2a;
   color: #ff6a6a;

--- a/src/components/TaskList.test.tsx
+++ b/src/components/TaskList.test.tsx
@@ -21,6 +21,7 @@ describe('TaskList', () => {
     const onSelect = vi.fn();
     const onComplete = vi.fn();
     const onDelete = vi.fn();
+    const onHistory = vi.fn();
 
     render(
       <TaskList
@@ -29,6 +30,7 @@ describe('TaskList', () => {
         onSelect={onSelect}
         onComplete={onComplete}
         onDelete={onDelete}
+        onHistory={onHistory}
       />
     );
 
@@ -41,6 +43,7 @@ describe('TaskList', () => {
     const onSelect = vi.fn();
     const onComplete = vi.fn();
     const onDelete = vi.fn();
+    const onHistory = vi.fn();
 
     render(
       <TaskList
@@ -49,6 +52,7 @@ describe('TaskList', () => {
         onSelect={onSelect}
         onComplete={onComplete}
         onDelete={onDelete}
+        onHistory={onHistory}
       />
     );
 
@@ -61,6 +65,7 @@ describe('TaskList', () => {
     const onSelect = vi.fn();
     const onComplete = vi.fn();
     const onDelete = vi.fn();
+    const onHistory = vi.fn();
 
     render(
       <TaskList
@@ -69,6 +74,7 @@ describe('TaskList', () => {
         onSelect={onSelect}
         onComplete={onComplete}
         onDelete={onDelete}
+        onHistory={onHistory}
       />
     );
 
@@ -81,6 +87,7 @@ describe('TaskList', () => {
     const onSelect = vi.fn();
     const onComplete = vi.fn();
     const onDelete = vi.fn();
+    const onHistory = vi.fn();
 
     render(
       <TaskList
@@ -89,6 +96,7 @@ describe('TaskList', () => {
         onSelect={onSelect}
         onComplete={onComplete}
         onDelete={onDelete}
+        onHistory={onHistory}
       />
     );
 
@@ -101,6 +109,7 @@ describe('TaskList', () => {
     const onSelect = vi.fn();
     const onComplete = vi.fn();
     const onDelete = vi.fn();
+    const onHistory = vi.fn();
 
     render(
       <TaskList
@@ -109,6 +118,7 @@ describe('TaskList', () => {
         onSelect={onSelect}
         onComplete={onComplete}
         onDelete={onDelete}
+        onHistory={onHistory}
       />
     );
 
@@ -121,6 +131,7 @@ describe('TaskList', () => {
     const onSelect = vi.fn();
     const onComplete = vi.fn();
     const onDelete = vi.fn();
+    const onHistory = vi.fn();
 
     render(
       <TaskList
@@ -129,6 +140,7 @@ describe('TaskList', () => {
         onSelect={onSelect}
         onComplete={onComplete}
         onDelete={onDelete}
+        onHistory={onHistory}
       />
     );
 
@@ -141,6 +153,7 @@ describe('TaskList', () => {
     const onSelect = vi.fn();
     const onComplete = vi.fn();
     const onDelete = vi.fn();
+    const onHistory = vi.fn();
 
     render(
       <TaskList
@@ -149,6 +162,7 @@ describe('TaskList', () => {
         onSelect={onSelect}
         onComplete={onComplete}
         onDelete={onDelete}
+        onHistory={onHistory}
       />
     );
 
@@ -161,6 +175,7 @@ describe('TaskList', () => {
     const onSelect = vi.fn();
     const onComplete = vi.fn();
     const onDelete = vi.fn();
+    const onHistory = vi.fn();
 
     render(
       <TaskList
@@ -169,6 +184,7 @@ describe('TaskList', () => {
         onSelect={onSelect}
         onComplete={onComplete}
         onDelete={onDelete}
+        onHistory={onHistory}
       />
     );
 
@@ -184,6 +200,7 @@ describe('TaskList', () => {
     const onSelect = vi.fn();
     const onComplete = vi.fn();
     const onDelete = vi.fn();
+    const onHistory = vi.fn();
 
     render(
       <TaskList
@@ -192,6 +209,7 @@ describe('TaskList', () => {
         onSelect={onSelect}
         onComplete={onComplete}
         onDelete={onDelete}
+        onHistory={onHistory}
       />
     );
 
@@ -209,6 +227,7 @@ describe('TaskList', () => {
     const onSelect = vi.fn();
     const onComplete = vi.fn();
     const onDelete = vi.fn();
+    const onHistory = vi.fn();
 
     render(
       <TaskList
@@ -217,6 +236,7 @@ describe('TaskList', () => {
         onSelect={onSelect}
         onComplete={onComplete}
         onDelete={onDelete}
+        onHistory={onHistory}
       />
     );
 
@@ -229,6 +249,7 @@ describe('TaskList', () => {
     const onSelect = vi.fn();
     const onComplete = vi.fn();
     const onDelete = vi.fn();
+    const onHistory = vi.fn();
 
     render(
       <TaskList
@@ -237,6 +258,7 @@ describe('TaskList', () => {
         onSelect={onSelect}
         onComplete={onComplete}
         onDelete={onDelete}
+        onHistory={onHistory}
       />
     );
 
@@ -251,6 +273,7 @@ describe('TaskList', () => {
     const onSelect = vi.fn();
     const onComplete = vi.fn();
     const onDelete = vi.fn();
+    const onHistory = vi.fn();
 
     render(
       <TaskList
@@ -259,6 +282,7 @@ describe('TaskList', () => {
         onSelect={onSelect}
         onComplete={onComplete}
         onDelete={onDelete}
+        onHistory={onHistory}
       />
     );
 
@@ -273,6 +297,7 @@ describe('TaskList', () => {
     const onSelect = vi.fn();
     const onComplete = vi.fn();
     const onDelete = vi.fn();
+    const onHistory = vi.fn();
 
     render(
       <TaskList
@@ -281,6 +306,7 @@ describe('TaskList', () => {
         onSelect={onSelect}
         onComplete={onComplete}
         onDelete={onDelete}
+        onHistory={onHistory}
       />
     );
 
@@ -294,6 +320,7 @@ describe('TaskList', () => {
     const onSelect = vi.fn();
     const onComplete = vi.fn();
     const onDelete = vi.fn();
+    const onHistory = vi.fn();
 
     render(
       <TaskList
@@ -302,6 +329,7 @@ describe('TaskList', () => {
         onSelect={onSelect}
         onComplete={onComplete}
         onDelete={onDelete}
+        onHistory={onHistory}
       />
     );
 
@@ -314,6 +342,7 @@ describe('TaskList', () => {
     const onSelect = vi.fn();
     const onComplete = vi.fn();
     const onDelete = vi.fn();
+    const onHistory = vi.fn();
 
     render(
       <TaskList
@@ -322,6 +351,7 @@ describe('TaskList', () => {
         onSelect={onSelect}
         onComplete={onComplete}
         onDelete={onDelete}
+        onHistory={onHistory}
       />
     );
 
@@ -336,6 +366,7 @@ describe('TaskList', () => {
     const onSelect = vi.fn();
     const onComplete = vi.fn();
     const onDelete = vi.fn();
+    const onHistory = vi.fn();
 
     render(
       <TaskList
@@ -344,6 +375,7 @@ describe('TaskList', () => {
         onSelect={onSelect}
         onComplete={onComplete}
         onDelete={onDelete}
+        onHistory={onHistory}
       />
     );
 
@@ -358,6 +390,7 @@ describe('TaskList', () => {
     const onSelect = vi.fn();
     const onComplete = vi.fn();
     const onDelete = vi.fn();
+    const onHistory = vi.fn();
 
     render(
       <TaskList
@@ -366,9 +399,57 @@ describe('TaskList', () => {
         onSelect={onSelect}
         onComplete={onComplete}
         onDelete={onDelete}
+        onHistory={onHistory}
       />
     );
 
     expect(screen.queryByText(/次:/)).not.toBeInTheDocument();
+  });
+
+  it('calls onHistory when clicking history button', async () => {
+    const user = userEvent.setup();
+    const task = createTask({ status: 'paused' });
+    const onSelect = vi.fn();
+    const onComplete = vi.fn();
+    const onDelete = vi.fn();
+    const onHistory = vi.fn();
+
+    render(
+      <TaskList
+        tasks={[task]}
+        activeTaskId={null}
+        onSelect={onSelect}
+        onComplete={onComplete}
+        onDelete={onDelete}
+        onHistory={onHistory}
+      />
+    );
+
+    await user.click(screen.getByTitle('更新履歴'));
+
+    expect(onHistory).toHaveBeenCalledWith(task);
+  });
+
+  it('shows history button for both active and completed tasks', () => {
+    const activeTask = createTask({ id: '1', status: 'paused', name: 'Active Task' });
+    const completedTask = createTask({ id: '2', status: 'completed', name: 'Completed Task' });
+    const onSelect = vi.fn();
+    const onComplete = vi.fn();
+    const onDelete = vi.fn();
+    const onHistory = vi.fn();
+
+    render(
+      <TaskList
+        tasks={[activeTask, completedTask]}
+        activeTaskId={null}
+        onSelect={onSelect}
+        onComplete={onComplete}
+        onDelete={onDelete}
+        onHistory={onHistory}
+      />
+    );
+
+    const historyButtons = screen.getAllByTitle('更新履歴');
+    expect(historyButtons).toHaveLength(2);
   });
 });

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -7,9 +7,10 @@ interface TaskListProps {
   onSelect: (task: Task) => void;
   onComplete: (task: Task) => void;
   onDelete: (task: Task) => void;
+  onHistory: (task: Task) => void;
 }
 
-export function TaskList({ tasks, activeTaskId, onSelect, onComplete, onDelete }: TaskListProps) {
+export function TaskList({ tasks, activeTaskId, onSelect, onComplete, onDelete, onHistory }: TaskListProps) {
   const activeTasks = tasks.filter((t) => t.status !== 'completed');
   const completedTasks = tasks.filter((t) => t.status === 'completed');
 
@@ -59,6 +60,13 @@ export function TaskList({ tasks, activeTaskId, onSelect, onComplete, onDelete }
             ✓
           </button>
         )}
+        <button
+          className="task-btn history-btn"
+          onClick={(e) => { e.stopPropagation(); onHistory(task); }}
+          title="更新履歴"
+        >
+          📜
+        </button>
         <button
           className="task-btn delete-btn"
           onClick={(e) => { e.stopPropagation(); onDelete(task); }}

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import type { Task, SavePointData } from '../types';
+import type { Task, SavePointData, TaskHistoryEntry } from '../types';
 
 const API_BASE = '/api/tasks';
 
@@ -112,6 +112,17 @@ export function useTasks() {
     }
   }, [updateTask, activeTaskId]);
 
+  const fetchHistory = useCallback(async (taskId: string): Promise<TaskHistoryEntry[]> => {
+    try {
+      const res = await fetch(`${API_BASE}/${taskId}/history`);
+      if (!res.ok) throw new Error('Failed to fetch history');
+      return await res.json();
+    } catch (error) {
+      console.error('Failed to fetch history:', error);
+      return [];
+    }
+  }, []);
+
   const activeTask = tasks.find((t) => t.id === activeTaskId) || null;
 
   return {
@@ -124,5 +135,6 @@ export function useTasks() {
     deleteTask,
     saveAndSwitch,
     completeTask,
+    fetchHistory,
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,3 +17,13 @@ export interface SavePointData {
   nextStep: string;
   remaining: string;
 }
+
+export interface TaskHistoryEntry {
+  id: number;
+  taskId: string;
+  status: TaskStatus;
+  progress: string;
+  nextStep: string;
+  remaining: string;
+  savedAt: number;
+}


### PR DESCRIPTION
## 変更内容

Closes #18

### バックエンド
- `server/db.ts`: `task_history` テーブルを追加（`FOREIGN KEY ON DELETE CASCADE`）
- `server/routes/tasks.ts`: PUTエンドポイントでステータス/進捗変更時に履歴を記録、`GET /:id/history` エンドポイントを追加

### フロントエンド
- `src/types.ts`: `TaskHistoryEntry` 型を追加
- `src/hooks/useTasks.ts`: `fetchHistory` 関数を追加
- `src/components/TaskHistoryModal.tsx`: ツリービューUIの履歴モーダルを新規作成
- `src/components/TaskHistoryModal.css`: 対応するスタイルを追加
- `src/components/TaskList.tsx`: `onHistory` プロップと📜ボタンを追加
- `src/components/TaskList.css`: `.history-btn` スタイルを追加
- `src/App.tsx`: `history` モーダル状態と `TaskHistoryModal` レンダリングを追加

### テスト
- `TaskHistoryModal.test.tsx`: 10テスト追加（ローディング・空状態・履歴表示・ステータスラベル・クローズ動作など）
- `TaskList.test.tsx`: 全テストに `onHistory` プロップを追加、2テスト新規追加

## テスト結果

全テスト通過（83テスト）

🤖 Generated with [Claude Code](https://claude.com/claude-code)